### PR TITLE
Re-use variable instead of calling method twice

### DIFF
--- a/custom-list-table-db-example.php
+++ b/custom-list-table-db-example.php
@@ -347,7 +347,7 @@ class Custom_Table_Example_List_Table extends WP_List_Table
 
         // prepare query params, as usual current page, order by and order direction
         $paged = isset($_REQUEST['paged']) ? max(0, intval($_REQUEST['paged'] - 1) * $per_page) : 0;
-        $orderby = (isset($_REQUEST['orderby']) && in_array($_REQUEST['orderby'], array_keys($this->get_sortable_columns()))) ? $_REQUEST['orderby'] : 'name';
+        $orderby = (isset($_REQUEST['orderby']) && in_array($_REQUEST['orderby'], array_keys($sortable))) ? $_REQUEST['orderby'] : 'name';
         $order = (isset($_REQUEST['order']) && in_array($_REQUEST['order'], array('asc', 'desc'))) ? $_REQUEST['order'] : 'asc';
 
         // [REQUIRED] define $items array


### PR DESCRIPTION
Re-use `$sortable` instead of calling `$this->get_sortable_columns()` twice.