### PR TITLE
Do not set pagination argument 'total_pages'

### DIFF
--- a/custom-list-table-db-example.php
+++ b/custom-list-table-db-example.php
@@ -358,7 +358,6 @@ class Custom_Table_Example_List_Table extends WP_List_Table
         $this->set_pagination_args(array(
             'total_items' => $total_items, // total items defined above
             'per_page' => $per_page, // per page constant defined at top of method
-            'total_pages' => ceil($total_items / $per_page) // calculate pages count
         ));
     }
 }


### PR DESCRIPTION
Avoid code duplication and let the parent method [set_pagination_args()](https://developer.wordpress.org/reference/classes/wp_list_table/set_pagination_args/) do the calculation.